### PR TITLE
Dialog - fix html enconding on dialog title

### DIFF
--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -442,7 +442,7 @@ $.widget( "ui.dialog", {
 
 	_title: function( title ) {
 		if ( this.options.title ) {
-			title.text( this.options.title );
+			title.html( this.options.title );
 		} else {
 			title.html( "&#160;" );
 		}


### PR DESCRIPTION
Component: Dialog 
today we have a problem using accentuation on title, changing text to html for support to encoding.
